### PR TITLE
bump: 0.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexteam/icons",
-  "version": "0.0.7-rc.0",
+  "version": "0.0.7",
   "main": "dist/index.umd.js",
   "module": "dist/index.mjs",
   "license": "MIT",


### PR DESCRIPTION
The previous PR #17 hasn't contain a version increment, so we need to patch it manually to publish the new version to NPM.