### PR TITLE
chore(nuxt): export icon names type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexteam/icons",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/index.umd.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexteam/icons",
-  "version": "0.1.0",
+  "version": "0.1.1-rc.0",
   "main": "dist/index.umd.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexteam/icons",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "main": "dist/index.umd.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexteam/nuxt-icons",
-  "version": "0.0.1-rc.1",
+  "version": "0.0.2",
   "description": "Use CodeX Icons in your Nuxt project",
   "main": "src/index.ts",
   "types": "src/types/index.ts",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1-rc.1",
   "description": "Use CodeX Icons in your Nuxt project",
   "main": "src/index.ts",
+  "types": "src/types/index.ts",
   "repository": "https://github.com/codex-team/icons/tree/master/packages/nuxt",
   "author": "CodeX",
   "license": "MIT",

--- a/packages/nuxt/src/runtime/components/icon.vue
+++ b/packages/nuxt/src/runtime/components/icon.vue
@@ -4,11 +4,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue';
-
-/**
- * Union type for available icon names
- */
-type CodexIconName = keyof typeof import('@codexteam/icons');
+import { CodexIconName } from '../../types';
 
 /**
  * Components properties

--- a/packages/nuxt/src/types/index.ts
+++ b/packages/nuxt/src/types/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Union type for available icon names
+ */
+export type CodexIconName = keyof typeof import('@codexteam/icons');


### PR DESCRIPTION
In the Nuxt module `<codex-icon>` component requires `name` to be one of available icon names. It is checking internally, but outside of this module, there is no ability to access the available icon names list. 

So I've exported a Union Type with available icon names.

<img width="1166" alt="image" src="https://user-images.githubusercontent.com/3684889/208187321-27b48e21-b6d7-449d-8a36-f5e6c0c110c7.png">

Now Nuxt module users can access icon names: 


```js
import type { CodexIconName } from '@codexteam/nuxt-icons';
```

It allows to create wrappers around `<codex-icon>`. In my example it is the `UiButton` component:

<img width="897" alt="image" src="https://user-images.githubusercontent.com/3684889/208188972-ef1f8178-c8e4-41c4-98ef-03ee5550ef97.png">
