### PR TITLE
fix: nuxt ssr mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexteam/icons",
-  "version": "0.2.1-rc.0",
+  "version": "0.2.1-rc.1",
   "main": "dist/index.umd.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -36,6 +36,16 @@ Use the `codex-icon` component with the `name` property which should be one of t
 <codex-icon name="IconHeart" />
 ```
 
+## Properties
+
+There are few properties available for component:
+
+| prop | type | description |
+| -- | -- | -- |
+| `name` | string | Required. Name of icon from CodeX Icons pack |
+| `class` | string | Class name to be added to the icon wrapper |
+| `size` | number | Icon width and height value |
+
 # About CodeX
 
 <img align="right" width="120" height="120" src="https://codex.so/public/app/img/codex-logo.svg" hspace="50">

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexteam/nuxt-icons",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Use CodeX Icons in your Nuxt project",
   "main": "src/index.ts",
   "types": "src/types/index.ts",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexteam/nuxt-icons",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Use CodeX Icons in your Nuxt project",
   "main": "src/index.ts",
   "types": "src/types/index.ts",

--- a/packages/nuxt/src/runtime/components/icon.vue
+++ b/packages/nuxt/src/runtime/components/icon.vue
@@ -1,9 +1,14 @@
 <template>
-  <span v-html="icon" v-inline-svg></span>
+  <span
+    class="cdx-icon"
+    :class="class"
+    v-html="icon"
+    ref="iconWrapper"
+  ></span>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
 import { CodexIconName } from '../../types';
 
 /**
@@ -14,30 +19,57 @@ const props = defineProps<{
    * Icon name, should be one of the names listed on https://github.com/codex-team/icons
    */
   name: CodexIconName,
+
+  /**
+   * Optional class names
+   */
+  class?: string,
+
+  /**
+   * Optional size if icon, for example: 20
+   */
+  size?:  number,
 }>()
 
 /**
  * Icon svg code to be inserted
  */
-const icon = ref('')
+const icon = ref<string>('')
 
 /**
- * Custom directive
- *
- * Used to replace <span><svg /></span> with just <svg />
- *  in construction like <span v-html="icon" v-inline-svg></span>
+ * Wrapper element reference
  */
-const vInlineSvg = {
-  mounted: (element: Element) => element.replaceWith(...element.children)
-}
+const iconWrapper = ref<HTMLElement|null>(null);
 
-try {
-  const icons = await import('@codexteam/icons')
+/**
+ * Map with all icons
+ */
+const icons = await import('@codexteam/icons')
 
-  const iconSource = icons[props.name];
+onMounted(() => {
+  try {
+    const iconSource = icons[props.name as CodexIconName];
 
-  icon.value = iconSource
-} catch {
-  console.error(`🛍 CodeX Icons: '${props.name}' doesn't exist in the pack`)
-}
+    icon.value = iconSource;
+
+    if (props.size !== undefined && iconWrapper.value !== null) {
+      iconWrapper.value.style.setProperty('--size', `${props.size}px`);
+    }
+  } catch {
+    console.error(`🛍 CodeX Icons: '${props.name}' doesn't exist in the pack`)
+  }
+})
 </script>
+
+<style>
+.cdx-icon {
+  --size: 24px;
+
+  display: inline-flex;
+}
+
+.cdx-icon svg {
+  width: var(--size);
+  height: var(--size);
+}
+</style>

--- a/packages/nuxt/src/runtime/components/icon.vue
+++ b/packages/nuxt/src/runtime/components/icon.vue
@@ -3,18 +3,22 @@
     class="cdx-icon"
     :class="class"
     v-html="icon"
-    ref="iconWrapper"
+    :style="style"
   ></span>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, computed } from 'vue';
 import { CodexIconName } from '../../types';
+/**
+ * Map with all icons
+ */
+import * as icons from '@codexteam/icons';
 
 /**
  * Components properties
  */
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   /**
    * Icon name, should be one of the names listed on https://github.com/codex-team/icons
    */
@@ -29,36 +33,34 @@ const props = defineProps<{
    * Optional size if icon, for example: 20
    */
   size?:  number,
-}>()
+}>(), {
+  size: 24
+})
 
 /**
  * Icon svg code to be inserted
  */
 const icon = ref<string>('')
 
-/**
- * Wrapper element reference
- */
-const iconWrapper = ref<HTMLElement|null>(null);
+let iconList: Record<CodexIconName, string>;
 
 /**
- * Map with all icons
+ * Workaround SSR problem when "import * as icons from '@codexteam/icons'" wraps with { default: ... }
  */
-const icons = await import('@codexteam/icons')
+if ('default' in icons){
+  iconList = (icons as unknown as {default: Record<CodexIconName, string>}).default;
+} else {
+  iconList = icons;
+}
 
-onMounted(() => {
-  try {
-    const iconSource = icons[props.name as CodexIconName];
-
-    icon.value = iconSource;
-
-    if (props.size !== undefined && iconWrapper.value !== null) {
-      iconWrapper.value.style.setProperty('--size', `${props.size}px`);
-    }
-  } catch {
-    console.error(`🛍 CodeX Icons: '${props.name}' doesn't exist in the pack`)
-  }
+/**
+ * Pass size variable to the CSS
+ */
+const style = computed(() => {
+  return `--size: ${props.size}px`;
 })
+
+icon.value = iconList[props.name as CodexIconName];
 </script>
 
 <style>


### PR DESCRIPTION
The previous version contained a custom directive `v-inline-svg` used to remove `v-html` wrapper and leave only `svg` tag. Unfortunately, custom directives with DOM access [are not working in SSR mode](https://vuejs.org/guide/scaling-up/ssr.html#custom-directives). So `nuxt generate` lacks to render icons.

I had to remove `v-inline-svg` so for now the `svg` tag will be wrapped in span:

```html
<span class="cdx-icon">
  <svg>...</svg>
</span>
```

To make it more useful some props were added: `class` and `size`. 