### PR TITLE
fix(types): export the types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexteam/icons",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "dist/index.umd.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "main": "dist/index.umd.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts"
+    }
+  },
   "license": "MIT",
   "scripts": {
     "build": "yarn generate && vite build",


### PR DESCRIPTION
## Problem:
The issue #44 where the user cannot use type declaration

## Cause:
Missing the export package in package.json

## Solution:
Add the export for types in the package.json