### PR TITLE
chore(package): update exports field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexteam/icons",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "dist/index.umd.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.umd.js",
       "types": "./dist/index.d.ts"
     }
   },


### PR DESCRIPTION

## Problem
Failed to resolve entry for package "@codexteam/icons". The package may have incorrect main/module/exports specified in its package.json: No known conditions for "." specifier in @codexteam/icons" package

## Cause
Incorrect exports path specified in `package.json`.

## Solution
Update the exports field with the correct paths in package.json to ensure proper module resolution.
```
  "exports": {
    ".": {
      "import": "./dist/index.mjs",
      "require": "./dist/index.umd.js",
      "types": "./dist/index.d.ts"
    }
  },
```